### PR TITLE
Prepare 2.1.0

### DIFF
--- a/urdf/CHANGELOG.rst
+++ b/urdf/CHANGELOG.rst
@@ -2,6 +2,18 @@
 Changelog for package urdf
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.1.0 (2018-06-25)
+------------------
+* Update project URLs (`#2 <https://github.com/ros2/urdf/issues/2>`_)
+* Contributors: Mikael Arguedas
+
+2.0.0 (2017-12-08)
+------------------
+* Ported to ROS 2
+* Added Windows compatibility
+* Switched to ROS 2 code style
+* Contributors: Chris Lalancette, Mikael Arguedas
+
 1.12.12 (2017-11-08)
 --------------------
 * Switched to package format 2 and made rostest a test_depend (`#221 <https://github.com/ros/robot_model/pull/221>`_)

--- a/urdf/package.xml
+++ b/urdf/package.xml
@@ -1,6 +1,6 @@
 <package format="2">
   <name>urdf</name>
-  <version>2.0.0</version>
+  <version>2.1.0</version>
   <description>
     This package contains a C++ parser for the Unified Robot Description
     Format (URDF), which is an XML format for representing a robot model.

--- a/urdf_parser_plugin/CHANGELOG.rst
+++ b/urdf_parser_plugin/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package urdf_parser_plugin
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.1.0 (2018-06-25)
+------------------
+* Update project URLs (`#2 <https://github.com/ros2/urdf/issues/2>`_)
+* Contributors: Mikael Arguedas
+
+2.0.0 (2017-12-08)
+------------------
+
 1.12.12 (2017-11-08)
 --------------------
 

--- a/urdf_parser_plugin/package.xml
+++ b/urdf_parser_plugin/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>urdf_parser_plugin</name>
-  <version>2.0.0</version>
+  <version>2.1.0</version>
   <description>
     This package contains a C++ base class for URDF parsers.
   </description>


### PR DESCRIPTION
I would update the changelog but it doesn't appear to've been updated for 2.0.0. I can put a filler line in 2.0.0 and add the changelog for 2.1.0 but I don't know that I can do a changelog for 2.0.0 while juggling other tasks.