### PR TITLE
urdf doesnt depend on console_bridge ATM

### DIFF
--- a/urdf/package.xml
+++ b/urdf/package.xml
@@ -21,7 +21,6 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
-  <build_depend>console_bridge</build_depend>
   <build_depend>tinyxml</build_depend>
   <build_depend>tinyxml_vendor</build_depend>
   <build_depend>urdfdom</build_depend>


### PR DESCRIPTION
connects to ros2/console_bridge_vendor#1