### PR TITLE
code style only: wrap after open parenthesis if not in one line

### DIFF
--- a/urdf/test/test_robot_model_parser.cpp
+++ b/urdf/test/test_robot_model_parser.cpp
@@ -75,7 +75,8 @@ protected:
 
   bool traverse_tree(urdf::LinkConstSharedPtr link, int level = 0)
   {
-    fprintf(stderr, "Traversing tree at level %d, link size %lu\n",
+    fprintf(
+      stderr, "Traversing tree at level %d, link size %lu\n",
       level, link->child_links.size());
     level += 2;
     bool retval = true;


### PR DESCRIPTION
Style update to match the ROS 2 development guide and pass with the updated linter configuration from ament/ament_lint#210.