### PR TITLE
force explicit language for uncrustify

### DIFF
--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -63,7 +63,7 @@ if(BUILD_TESTING)
   ament_cppcheck(LANGUAGE "c++")
   ament_cpplint()
   ament_lint_cmake()
-  ament_uncrustify()
+  ament_uncrustify(LANGUAGE "C++")
 endif()
 
 ament_export_libraries(${PROJECT_NAME})


### PR DESCRIPTION
Related to ament/ament_lint#214.

Similar as already done for `cppcheck`.