### PR TITLE
Remove urdf direct dependency on tinyxml

### DIFF
--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -4,8 +4,6 @@ project(urdf)
 find_package(ament_cmake_ros REQUIRED)
 find_package(urdfdom REQUIRED)
 find_package(urdfdom_headers REQUIRED)
-find_package(tinyxml_vendor REQUIRED)
-find_package(TinyXML REQUIRED)
 
 # Find version components
 if(NOT urdfdom_headers_VERSION)
@@ -35,7 +33,7 @@ target_include_directories(${PROJECT_NAME}
 ament_target_dependencies(${PROJECT_NAME}
   urdfdom
   urdfdom_headers
-  TinyXML)
+)
 
 if(WIN32)
   target_compile_definitions(${PROJECT_NAME} PRIVATE "URDF_BUILDING_DLL")
@@ -70,8 +68,6 @@ endif()
 ament_export_libraries(${PROJECT_NAME})
 ament_export_targets(${PROJECT_NAME})
 ament_export_include_directories(include)
-ament_export_dependencies(tinyxml_vendor)
-ament_export_dependencies(TinyXML)
 ament_export_dependencies(urdfdom)
 ament_export_dependencies(urdfdom_headers)
 ament_package()

--- a/urdf/include/urdf/model.h
+++ b/urdf/include/urdf/model.h
@@ -39,7 +39,6 @@
 
 #include <string>
 
-#include "tinyxml.h"  // NOLINT
 #include "urdf_model/model.h"
 
 #include "urdf/urdfdom_compatibility.h"
@@ -51,10 +50,6 @@ namespace urdf
 class Model : public ModelInterface
 {
 public:
-  /// \brief Load Model from TiXMLElement
-  URDF_EXPORT bool initXml(TiXmlElement * xml);
-  /// \brief Load Model from TiXMLDocument
-  URDF_EXPORT bool initXml(TiXmlDocument * xml);
   /// \brief Load Model given a filename
   URDF_EXPORT bool initFile(const std::string & filename);
   /// \brief Load Model given the name of a parameter on the parameter server

--- a/urdf/mainpage.dox
+++ b/urdf/mainpage.dox
@@ -58,7 +58,6 @@ The connection between links(nodes) and joints(edges) should define a tree (i.e.
 \section codeapi Code API
 
 The URDF parser API contains the following methods:
-  \li Parse and build tree from XML: urdf::Model::initXml
   \li Parse and build tree from File: urdf::Model::initFile
   \li Parse and build tree from String: urdf::Model::initString
   \li Get Root Link: urdf::Model::getRoot

--- a/urdf/package.xml
+++ b/urdf/package.xml
@@ -21,19 +21,14 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
-  <build_depend>tinyxml</build_depend>
-  <build_depend>tinyxml_vendor</build_depend>
   <build_depend>urdfdom</build_depend>
   <!-- use ROS 2 package urdfdom_headers until upstream provides 1.0.0.-->
   <build_depend>urdfdom_headers</build_depend>
 
-  <exec_depend>tinyxml</exec_depend>
-  <exec_depend>tinyxml_vendor</exec_depend>
   <exec_depend>urdfdom</exec_depend>
   <!-- use ROS 2 package urdfdom_headers until upstream provides 1.0.0.-->
   <exec_depend>urdfdom_headers</exec_depend>
 
-  <build_export_depend>tinyxml</build_export_depend>
   <!-- use ROS 2 package urdfdom_headers until upstream provides 1.0.0.-->
   <build_export_depend>urdfdom_headers</build_export_depend>
 

--- a/urdf/src/model.cpp
+++ b/urdf/src/model.cpp
@@ -98,32 +98,6 @@ bool Model::initParamWithNodeHandle(const std::string & param, const ros::NodeHa
 }
 */
 
-bool Model::initXml(TiXmlDocument * xml_doc)
-{
-  if (!xml_doc) {
-    fprintf(stderr, "Could not parse the xml document.\n");
-    return false;
-  }
-
-  std::stringstream ss;
-  ss << *xml_doc;
-
-  return Model::initString(ss.str());
-}
-
-bool Model::initXml(TiXmlElement * robot_xml)
-{
-  if (!robot_xml) {
-    fprintf(stderr, "Could not parse the xml element.\n");
-    return false;
-  }
-
-  std::stringstream ss;
-  ss << (*robot_xml);
-
-  return Model::initString(ss.str());
-}
-
 bool Model::initString(const std::string & xml_string)
 {
   urdf::ModelInterfaceSharedPtr model;


### PR DESCRIPTION
This clears the way for urdfdom to switch to TinyXML2
Depends on https://github.com/ros2/rviz/pull/531 and https://github.com/ros2/kdl_parser/pull/7
