### PR TITLE
Make urdf plugable and revive urdf_parser_plugin

### DIFF
--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -87,8 +87,34 @@ if(BUILD_TESTING)
   ament_lint_cmake()
   ament_uncrustify(LANGUAGE "C++")
 
+  # Write files to enable pluginlib to find urdf_xml_parser in build folder
+  set(fake_urdf_prefix "${CMAKE_CURRENT_BINARY_DIR}/fake_urdf_install")
+  # Copy urdf_xml_parser to fake prefix lib/ and bin/
+  file(MAKE_DIRECTORY "${fake_urdf_prefix}/lib")
+  file(MAKE_DIRECTORY "${fake_urdf_prefix}/bin")
+  add_custom_command(TARGET urdf_xml_parser
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:urdf_xml_parser>
+    "${fake_urdf_prefix}/lib/"
+  )
+  add_custom_command(TARGET urdf_xml_parser
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:urdf_xml_parser>
+    "${fake_urdf_prefix}/bin/"
+  )
+  # Fake install plugin description file
+  file(COPY "urdf_parser_description.xml" DESTINATION "${fake_urdf_prefix}/share/urdf/")
+  # Fake install package.xml
+  configure_file("package.xml" "${fake_urdf_prefix}/share/urdf/package.xml" COPYONLY)
+  # Fake install entry in ament_index telling pluginlib where to find plugin description
+  file(WRITE "${fake_urdf_prefix}/share/ament_index/resource_index/urdf_parser_plugin__pluginlib__plugin/urdf"
+    "share/urdf/urdf_parser_description.xml\n")
+  # Fake install entry in ament_index declaring this a package
+  file(WRITE "${fake_urdf_prefix}/share/ament_index/resource_index/packages/urdf" "")
+
   ament_add_google_benchmark(plugin_overhead
     test/benchmark_plugin_overhead.cpp
+    APPEND_ENV AMENT_PREFIX_PATH="${fake_urdf_prefix}"
   )
   target_link_libraries(plugin_overhead
     urdf

--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.5)
 project(urdf)
 
 find_package(ament_cmake_ros REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(urdf_parser_plugin REQUIRED)
 find_package(urdfdom REQUIRED)
 find_package(urdfdom_headers REQUIRED)
 find_package(tinyxml_vendor REQUIRED)
@@ -33,8 +35,10 @@ target_include_directories(${PROJECT_NAME}
   "$<INSTALL_INTERFACE:include>"
 )
 ament_target_dependencies(${PROJECT_NAME}
+  urdf_parser_plugin
   urdfdom
   urdfdom_headers
+  pluginlib
   TinyXML)
 
 if(WIN32)
@@ -44,6 +48,22 @@ endif()
 if(APPLE)
   set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
 endif()
+
+add_library(urdf_xml_parser MODULE
+  src/urdf_plugin.cpp
+)
+target_link_libraries(urdf_xml_parser
+  ${PROJECT_NAME}
+)
+ament_target_dependencies(urdf_xml_parser
+  "pluginlib"
+  "urdf_parser_plugin"
+)
+
+install(TARGETS urdf_xml_parser
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)
 
 install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
   ARCHIVE DESTINATION lib
@@ -70,8 +90,13 @@ endif()
 ament_export_libraries(${PROJECT_NAME})
 ament_export_targets(${PROJECT_NAME})
 ament_export_include_directories(include)
+ament_export_dependencies(pluginlib)
 ament_export_dependencies(tinyxml_vendor)
 ament_export_dependencies(TinyXML)
+ament_export_dependencies(urdf_parser_plugin)
 ament_export_dependencies(urdfdom)
 ament_export_dependencies(urdfdom_headers)
+
+pluginlib_export_plugin_description_file(urdf_parser_plugin "urdf_parser_description.xml")
+
 ament_package()

--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -76,6 +76,7 @@ install(DIRECTORY include/${PROJECT_NAME}/
 if(BUILD_TESTING)
   find_package(ament_cmake_cppcheck REQUIRED)
   find_package(ament_cmake_cpplint REQUIRED)
+  find_package(ament_cmake_google_benchmark REQUIRED)
   find_package(ament_cmake_lint_cmake REQUIRED)
   find_package(ament_cmake_uncrustify REQUIRED)
   # This forces cppcheck to consider all files in this project to be C++,
@@ -85,6 +86,13 @@ if(BUILD_TESTING)
   ament_cpplint()
   ament_lint_cmake()
   ament_uncrustify(LANGUAGE "C++")
+
+  ament_add_google_benchmark(plugin_overhead
+    test/benchmark_plugin_overhead.cpp
+  )
+  target_link_libraries(plugin_overhead
+    urdf
+  )
 endif()
 
 ament_export_libraries(${PROJECT_NAME})

--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -49,7 +49,7 @@ if(APPLE)
   set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
 endif()
 
-add_library(urdf_xml_parser MODULE
+add_library(urdf_xml_parser SHARED
   src/urdf_plugin.cpp
 )
 target_link_libraries(urdf_xml_parser

--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -87,38 +87,22 @@ if(BUILD_TESTING)
   ament_lint_cmake()
   ament_uncrustify(LANGUAGE "C++")
 
-  # Write files to enable pluginlib to find urdf_xml_parser in build folder
-  set(fake_urdf_prefix "${CMAKE_CURRENT_BINARY_DIR}/fake_urdf_install")
-  # Copy urdf_xml_parser to fake prefix lib/ and bin/
-  file(MAKE_DIRECTORY "${fake_urdf_prefix}/lib")
-  file(MAKE_DIRECTORY "${fake_urdf_prefix}/bin")
-  add_custom_command(TARGET urdf_xml_parser
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:urdf_xml_parser>
-    "${fake_urdf_prefix}/lib/"
+  pluginlib_enable_plugin_testing(
+    CMAKE_TARGET_VAR mock_install_target
+    AMENT_PREFIX_PATH_VAR mock_install_path
+    PLUGIN_CATEGORY "urdf_parser"
+    PLUGIN_DESCRIPTIONS "urdf_parser_description.xml"
+    PLUGIN_LIBRARIES urdf_xml_parser
   )
-  add_custom_command(TARGET urdf_xml_parser
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:urdf_xml_parser>
-    "${fake_urdf_prefix}/bin/"
-  )
-  # Fake install plugin description file
-  file(COPY "urdf_parser_description.xml" DESTINATION "${fake_urdf_prefix}/share/urdf/")
-  # Fake install package.xml
-  configure_file("package.xml" "${fake_urdf_prefix}/share/urdf/package.xml" COPYONLY)
-  # Fake install entry in ament_index telling pluginlib where to find plugin description
-  file(WRITE "${fake_urdf_prefix}/share/ament_index/resource_index/urdf_parser_plugin__pluginlib__plugin/urdf"
-    "share/urdf/urdf_parser_description.xml\n")
-  # Fake install entry in ament_index declaring this a package
-  file(WRITE "${fake_urdf_prefix}/share/ament_index/resource_index/packages/urdf" "")
 
   ament_add_google_benchmark(plugin_overhead
     test/benchmark_plugin_overhead.cpp
-    APPEND_ENV AMENT_PREFIX_PATH="${fake_urdf_prefix}"
+    APPEND_ENV AMENT_PREFIX_PATH="${mock_install_path}"
   )
   target_link_libraries(plugin_overhead
     urdf
   )
+  add_dependencies(plugin_overhead "${mock_install_target}")
 endif()
 
 ament_export_libraries(${PROJECT_NAME})

--- a/urdf/include/urdf/model.h
+++ b/urdf/include/urdf/model.h
@@ -67,13 +67,10 @@ public:
   /// \brief Load Model from TiXMLDocument
   [[deprecated("use initString instead")]]
   URDF_EXPORT bool initXml(TiXmlDocument * xml);
+
   /// \brief Load Model given a filename
   URDF_EXPORT bool initFile(const std::string & filename);
-  /// \brief Load Model given the name of a parameter on the parameter server
-  // URDF_EXPORT bool initParam(const std::string & param);
-  /// \brief Load Model given the name of parameter on parameter server using provided nodehandle
-  // URDF_EXPORT bool initParamWithNodeHandle(const std::string & param,
-  //   const ros::NodeHandle & nh = ros::NodeHandle());
+
   /// \brief Load Model from a XML-string
   URDF_EXPORT bool initString(const std::string & xmlstring);
 

--- a/urdf/include/urdf/model.h
+++ b/urdf/include/urdf/model.h
@@ -52,6 +52,12 @@ namespace urdf
 // Forward Declaration
 class ModelImplementation;
 
+/// \brief Populates itself based on a robot descripton
+///
+/// This class uses `urdf_parser_plugin` to parse the given robot description.
+/// The picked plugin is the one that reports the most confident score.
+/// There is no way to override this choice except by uninstalling undesirable
+/// parser plugins.
 class Model : public ModelInterface
 {
 public:

--- a/urdf/include/urdf/model.h
+++ b/urdf/include/urdf/model.h
@@ -59,7 +59,7 @@ public:
   Model();
 
   URDF_EXPORT
-  virtual ~Model();
+  ~Model();
 
   /// \brief Load Model from TiXMLElement
   [[deprecated("use initString instead")]]

--- a/urdf/include/urdf/model.h
+++ b/urdf/include/urdf/model.h
@@ -49,7 +49,7 @@
 namespace urdf
 {
 
-// Forward Declaration
+// PIMPL Forward Declaration
 class ModelImplementation;
 
 /// \brief Populates itself based on a robot descripton

--- a/urdf/include/urdf/model.h
+++ b/urdf/include/urdf/model.h
@@ -55,7 +55,7 @@ class ModelImplementation;
 /// \brief Populates itself based on a robot descripton
 ///
 /// This class uses `urdf_parser_plugin` to parse the given robot description.
-/// The picked plugin is the one that reports the most confident score.
+/// The chosen plugin is the one that reports the most confident score.
 /// There is no way to override this choice except by uninstalling undesirable
 /// parser plugins.
 class Model : public ModelInterface

--- a/urdf/package.xml
+++ b/urdf/package.xml
@@ -23,7 +23,7 @@
 
   <build_depend>tinyxml</build_depend>
   <build_depend>tinyxml_vendor</build_depend>
-  <!--<build_depend>urdfdom</build_depend>-->
+  <build_depend>urdfdom</build_depend>
   <!-- use ROS 2 package urdfdom_headers until upstream provides 1.0.0.-->
   <build_depend>urdf_parser_plugin</build_depend>
   <build_depend>urdfdom_headers</build_depend>
@@ -31,13 +31,14 @@
 
   <exec_depend>tinyxml</exec_depend>
   <exec_depend>tinyxml_vendor</exec_depend>
-  <!--<exec_depend>urdfdom</exec_depend>-->
+  <exec_depend>urdfdom</exec_depend>
   <!-- use ROS 2 package urdfdom_headers until upstream provides 1.0.0.-->
   <exec_depend>urdfdom_headers</exec_depend>
   <exec_depend>pluginlib</exec_depend>
 
   <build_export_depend>tinyxml</build_export_depend>
   <build_export_depend>urdf_parser_plugin</build_export_depend>
+  <build_export_depend>urdfdom</build_export_depend>
   <!-- use ROS 2 package urdfdom_headers until upstream provides 1.0.0.-->
   <build_export_depend>urdfdom_headers</build_export_depend>
   <build_export_depend>pluginlib</build_export_depend>

--- a/urdf/package.xml
+++ b/urdf/package.xml
@@ -45,6 +45,7 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_google_benchmark</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/urdf/package.xml
+++ b/urdf/package.xml
@@ -25,8 +25,8 @@
   <build_depend>tinyxml</build_depend>
   <build_depend>tinyxml_vendor</build_depend>
   <build_depend>urdfdom</build_depend>
-  <!-- use ROS 2 package urdfdom_headers until upstream provides 1.0.0.-->
   <build_depend>urdf_parser_plugin</build_depend>
+  <!-- use ROS 2 package urdfdom_headers until upstream provides 1.0.0.-->
   <build_depend>urdfdom_headers</build_depend>
 
   <exec_depend>pluginlib</exec_depend>

--- a/urdf/package.xml
+++ b/urdf/package.xml
@@ -21,31 +21,31 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
+  <build_depend>pluginlib</build_depend>
   <build_depend>tinyxml</build_depend>
   <build_depend>tinyxml_vendor</build_depend>
   <build_depend>urdfdom</build_depend>
   <!-- use ROS 2 package urdfdom_headers until upstream provides 1.0.0.-->
   <build_depend>urdf_parser_plugin</build_depend>
   <build_depend>urdfdom_headers</build_depend>
-  <build_depend>pluginlib</build_depend>
 
+  <exec_depend>pluginlib</exec_depend>
   <exec_depend>tinyxml</exec_depend>
   <exec_depend>tinyxml_vendor</exec_depend>
   <exec_depend>urdfdom</exec_depend>
   <!-- use ROS 2 package urdfdom_headers until upstream provides 1.0.0.-->
   <exec_depend>urdfdom_headers</exec_depend>
-  <exec_depend>pluginlib</exec_depend>
 
+  <build_export_depend>pluginlib</build_export_depend>
   <build_export_depend>tinyxml</build_export_depend>
   <build_export_depend>urdf_parser_plugin</build_export_depend>
   <build_export_depend>urdfdom</build_export_depend>
   <!-- use ROS 2 package urdfdom_headers until upstream provides 1.0.0.-->
   <build_export_depend>urdfdom_headers</build_export_depend>
-  <build_export_depend>pluginlib</build_export_depend>
 
+  <test_depend>ament_cmake_google_benchmark</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  <test_depend>ament_cmake_google_benchmark</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/urdf/package.xml
+++ b/urdf/package.xml
@@ -23,19 +23,24 @@
 
   <build_depend>tinyxml</build_depend>
   <build_depend>tinyxml_vendor</build_depend>
-  <build_depend>urdfdom</build_depend>
+  <!--<build_depend>urdfdom</build_depend>-->
   <!-- use ROS 2 package urdfdom_headers until upstream provides 1.0.0.-->
+  <build_depend>urdf_parser_plugin</build_depend>
   <build_depend>urdfdom_headers</build_depend>
+  <build_depend>pluginlib</build_depend>
 
   <exec_depend>tinyxml</exec_depend>
   <exec_depend>tinyxml_vendor</exec_depend>
-  <exec_depend>urdfdom</exec_depend>
+  <!--<exec_depend>urdfdom</exec_depend>-->
   <!-- use ROS 2 package urdfdom_headers until upstream provides 1.0.0.-->
   <exec_depend>urdfdom_headers</exec_depend>
+  <exec_depend>pluginlib</exec_depend>
 
   <build_export_depend>tinyxml</build_export_depend>
+  <build_export_depend>urdf_parser_plugin</build_export_depend>
   <!-- use ROS 2 package urdfdom_headers until upstream provides 1.0.0.-->
   <build_export_depend>urdfdom_headers</build_export_depend>
+  <build_export_depend>pluginlib</build_export_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/urdf/src/model.cpp
+++ b/urdf/src/model.cpp
@@ -163,7 +163,12 @@ bool Model::initString(const std::string & data)
       fprintf(stderr, "Failed to load urdf_parser_plugin [%s]\n", plugin_name.c_str());
       continue;
     }
-    assert(plugin_instance);
+    if (!plugin_instance) {
+      // Debug mode
+      assert(plugin_instance);
+      // Release mode
+      continue;
+    }
     size_t score = plugin_instance->might_handle(data);
     if (score < best_score) {
       best_score = score;

--- a/urdf/src/model.cpp
+++ b/urdf/src/model.cpp
@@ -180,15 +180,16 @@ bool Model::initString(const std::string & data)
   model = best_plugin->parse(data);
 
   // copy data from model into this object
-  if (model) {
-    this->links_ = model->links_;
-    this->joints_ = model->joints_;
-    this->materials_ = model->materials_;
-    this->name_ = model->name_;
-    this->root_link_ = model->root_link_;
-    return true;
+  if (!model) {
+    fprintf(stderr, "Failed to parse robot description using: %s\n", best_plugin_name.c_str());
+    return false;
   }
-  fprintf(stderr, "Failed to parse robot description using: %s\n", best_plugin_name.c_str());
-  return false;
+
+  this->links_ = model->links_;
+  this->joints_ = model->joints_;
+  this->materials_ = model->materials_;
+  this->name_ = model->name_;
+  this->root_link_ = model->root_link_;
+  return true;
 }
 }  // namespace urdf

--- a/urdf/src/model.cpp
+++ b/urdf/src/model.cpp
@@ -159,7 +159,7 @@ bool Model::initString(const std::string & data)
     pluginlib::UniquePtr<urdf::URDFParser> plugin_instance;
     try {
       plugin_instance = impl_->loader_.createUniqueInstance(plugin_name);
-    } catch (const pluginlib::CreateClassException & exec) {
+    } catch (const pluginlib::CreateClassException &) {
       fprintf(stderr, "Failed to load urdf_parser_plugin [%s]\n", plugin_name.c_str());
       continue;
     }

--- a/urdf/src/model.cpp
+++ b/urdf/src/model.cpp
@@ -49,7 +49,7 @@
 
 namespace urdf
 {
-class ModelImplementation
+class ModelImplementation final
 {
 public:
   ModelImplementation()

--- a/urdf/src/model.cpp
+++ b/urdf/src/model.cpp
@@ -70,6 +70,8 @@ Model::Model()
 
 Model::~Model()
 {
+  clear();
+  impl_.reset();
 }
 
 

--- a/urdf/src/model.cpp
+++ b/urdf/src/model.cpp
@@ -74,7 +74,6 @@ Model::~Model()
   impl_.reset();
 }
 
-
 bool Model::initFile(const std::string & filename)
 {
   // get the entire file

--- a/urdf/src/model.cpp
+++ b/urdf/src/model.cpp
@@ -165,7 +165,7 @@ bool Model::initString(const std::string & data)
   urdf::ModelInterfaceSharedPtr model;
 
   size_t best_score = std::numeric_limits<size_t>::max();
-  pluginlib::UniquePtr<urdf::URDFParser> best_plugin;
+  auto best_plugin = pluginlib::UniquePtr<urdf::URDFParser>{nullptr};
   std::string best_plugin_name;
 
   // Figure out what plugins might handle this format

--- a/urdf/src/model.cpp
+++ b/urdf/src/model.cpp
@@ -37,21 +37,40 @@
 #include <fstream>
 #include <iostream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "urdf/model.h"
 
 /* we include the default parser for plain URDF files;
    other parsers are loaded via plugins (if available) */
-#include "urdf_parser/urdf_parser.h"
+#include <urdf_parser_plugin/parser.h>
+#include <pluginlib/class_loader.hpp>
 
 namespace urdf
 {
-
-static bool IsColladaData(const std::string & data)
+class ModelImplementation
 {
-  return data.find("<COLLADA") != std::string::npos;
+public:
+  ModelImplementation() : loader_("urdf_parser_plugin", "urdf::URDFParser")
+  {
+  }
+
+  ~ModelImplementation() = default;
+
+  // Loader used to get plugins
+  pluginlib::ClassLoader<urdf::URDFParser> loader_;
+};
+
+
+Model::Model() : impl_(new ModelImplementation)
+{
 }
+
+Model::~Model()
+{
+}
+
 
 bool Model::initFile(const std::string & filename)
 {
@@ -124,49 +143,34 @@ bool Model::initXml(TiXmlElement * robot_xml)
   return Model::initString(ss.str());
 }
 
-bool Model::initString(const std::string & xml_string)
+bool Model::initString(const std::string & data)
 {
   urdf::ModelInterfaceSharedPtr model;
 
-  // necessary for COLLADA compatibility
-  if (IsColladaData(xml_string)) {
-    fprintf(stderr, "Parsing robot collada xml string is not yet supported.\n");
+  size_t best_score = std::numeric_limits<size_t>::max();
+  pluginlib::UniquePtr<urdf::URDFParser> best_plugin;
+  std::string best_plugin_name;
+
+  // Figure out what plugins might handle this format
+  for (const std::string & plugin_name : impl_->loader_.getDeclaredClasses()) {
+    pluginlib::UniquePtr<urdf::URDFParser> plugin_instance =
+      impl_->loader_.createUniqueInstance(plugin_name);
+    if (plugin_instance) {
+      size_t score = plugin_instance->might_handle(data);
+      if (score < best_score) {
+        best_score = score;
+        best_plugin = std::move(plugin_instance);
+        best_plugin_name = plugin_name;
+      }
+    }
+  };
+
+  if (!best_plugin) {
+    fprintf(stderr, "No plugin found for given robot description.\n");
     return false;
-    /*
-    ROS_DEBUG("Parsing robot collada xml string");
-
-    static boost::mutex PARSER_PLUGIN_LOCK;
-    static boost::scoped_ptr<pluginlib::ClassLoader<urdf::URDFParser> > PARSER_PLUGIN_LOADER;
-    boost::mutex::scoped_lock _(PARSER_PLUGIN_LOCK);
-
-    try
-    {
-      if (!PARSER_PLUGIN_LOADER)
-        PARSER_PLUGIN_LOADER.reset(new pluginlib::ClassLoader<urdf::URDFParser>("urdf_parser_plugin", "urdf::URDFParser"));
-     const std::vector<std::string> &classes = PARSER_PLUGIN_LOADER->getDeclaredClasses();
-     bool found = false;
-     for (std::size_t i = 0 ; i < classes.size() ; ++i)
-       if (classes[i].find("urdf/ColladaURDFParser") != std::string::npos)
-     {
-       boost::shared_ptr<urdf::URDFParser> instance = PARSER_PLUGIN_LOADER->createInstance(classes[i]);
-       if (instance)
-         model = instance->parse(xml_string);
-       found = true;
-       break;
-     }
-     if (!found)
-       ROS_ERROR_STREAM("No URDF parser plugin found for Collada files. Did you install the corresponding package?");
-   }
-   catch(pluginlib::PluginlibException& ex)
-   {
-     ROS_ERROR_STREAM("Exception while creating planning plugin loader " << ex.what() << ". Will not parse Collada file.");
-   }
   }
-   */
-  } else {
-    fprintf(stderr, "Parsing robot urdf xml string.\n");
-    model = parseURDF(xml_string);
-  }
+
+  model = best_plugin->parse(data);
 
   // copy data from model into this object
   if (model) {
@@ -177,6 +181,7 @@ bool Model::initString(const std::string & xml_string)
     this->root_link_ = model->root_link_;
     return true;
   }
+  fprintf(stderr, "Failed to parse robot description using: %s\n", best_plugin_name.c_str());
   return false;
 }
 }  // namespace urdf

--- a/urdf/src/model.cpp
+++ b/urdf/src/model.cpp
@@ -34,25 +34,25 @@
 
 /* Author: Wim Meeussen */
 
+#include "urdf/model.h"
+#include <urdf_parser_plugin/parser.h>
+#include <pluginlib/class_loader.hpp>
+
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <string>
 #include <utility>
 #include <vector>
 
-#include "urdf/model.h"
-
-/* we include the default parser for plain URDF files;
-   other parsers are loaded via plugins (if available) */
-#include <urdf_parser_plugin/parser.h>
-#include <pluginlib/class_loader.hpp>
 
 namespace urdf
 {
 class ModelImplementation
 {
 public:
-  ModelImplementation() : loader_("urdf_parser_plugin", "urdf::URDFParser")
+  ModelImplementation()
+  : loader_("urdf_parser_plugin", "urdf::URDFParser")
   {
   }
 
@@ -63,7 +63,8 @@ public:
 };
 
 
-Model::Model() : impl_(new ModelImplementation)
+Model::Model()
+: impl_(new ModelImplementation)
 {
 }
 
@@ -163,7 +164,7 @@ bool Model::initString(const std::string & data)
         best_plugin_name = plugin_name;
       }
     }
-  };
+  }
 
   if (!best_plugin) {
     fprintf(stderr, "No plugin found for given robot description.\n");

--- a/urdf/src/urdf_plugin.cpp
+++ b/urdf/src/urdf_plugin.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
 * Software License Agreement (BSD License)
 *
-*  Copyright (c) 2020, Willow Garage, Inc.
+*  Copyright (c) 2020, Open Source Robotics Foundation, Inc.
 *  All rights reserved.
 *
 *  Redistribution and use in source and binary forms, with or without

--- a/urdf/src/urdf_plugin.cpp
+++ b/urdf/src/urdf_plugin.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
 * Software License Agreement (BSD License)
 *
-*  Copyright (c) 2008, Willow Garage, Inc.
+*  Copyright (c) 2020, Willow Garage, Inc.
 *  All rights reserved.
 *
 *  Redistribution and use in source and binary forms, with or without
@@ -32,58 +32,35 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-/* Author: Wim Meeussen */
-
-#ifndef URDF__MODEL_H_
-#define URDF__MODEL_H_
-
-#include <memory>
-#include <string>
-
-#include "tinyxml.h"  // NOLINT
-#include "urdf_model/model.h"
-
-#include "urdf/urdfdom_compatibility.h"
-#include "urdf/visibility_control.hpp"
+#include <urdf_parser/urdf_parser.h>
+#include <urdf_parser_plugin/parser.h>
 
 namespace urdf
 {
-
-// Forward Declaration
-class ModelImplementation;
-
-class Model : public ModelInterface
+class URDFXMLParser : public urdf::URDFParser
 {
 public:
-  URDF_EXPORT
-  Model();
 
-  URDF_EXPORT
-  virtual ~Model();
+  URDFXMLParser() = default;
 
-  /// \brief Load Model from TiXMLElement
-  [[deprecated("use initString instead")]]
-  URDF_EXPORT bool initXml(TiXmlElement * xml);
-  /// \brief Load Model from TiXMLDocument
-  [[deprecated("use initString instead")]]
-  URDF_EXPORT bool initXml(TiXmlDocument * xml);
-  /// \brief Load Model given a filename
-  URDF_EXPORT bool initFile(const std::string & filename);
-  /// \brief Load Model given the name of a parameter on the parameter server
-  // URDF_EXPORT bool initParam(const std::string & param);
-  /// \brief Load Model given the name of parameter on parameter server using provided nodehandle
-  // URDF_EXPORT bool initParamWithNodeHandle(const std::string & param,
-  //   const ros::NodeHandle & nh = ros::NodeHandle());
-  /// \brief Load Model from a XML-string
-  URDF_EXPORT bool initString(const std::string & xmlstring);
+  virtual ~URDFXMLParser() = default;
 
-private:
-  std::unique_ptr<ModelImplementation> impl_;
+  urdf::ModelInterfaceSharedPtr parse(const std::string& xml_string) override;
+
+  size_t might_handle(const std::string & data) override;
 };
 
-// shared_ptr declarations moved to urdf/urdfdom_compatibility.h to allow for
-// std::shared_ptrs in latest version
+urdf::ModelInterfaceSharedPtr URDFXMLParser::parse(const std::string &xml_string)
+{
+  return urdf::parseURDF(xml_string);
+}
 
+size_t URDFXMLParser::might_handle(const std::string &data)
+{
+  // probably a urdf file if <robot is near the start of the document
+  return data.find("<robot");
+}
 }  // namespace urdf
 
-#endif  // URDF__MODEL_H_
+#include <pluginlib/class_list_macros.hpp>  // NOLINT
+PLUGINLIB_EXPORT_CLASS(urdf::URDFXMLParser, urdf::URDFParser)

--- a/urdf/src/urdf_plugin.cpp
+++ b/urdf/src/urdf_plugin.cpp
@@ -66,7 +66,6 @@ size_t URDFXMLParser::might_handle(const std::string & data)
     // Since it's an XML document it must have `<robot>` as the first tag
     const tinyxml2::XMLElement * root = doc.RootElement();
     if (std::string("robot") != root->Name()) {
-      std::cout << "'" << root->Name() << "'\n";
       return std::numeric_limits<size_t>::max();
     }
   }

--- a/urdf/src/urdf_plugin.cpp
+++ b/urdf/src/urdf_plugin.cpp
@@ -35,27 +35,28 @@
 #include <urdf_parser/urdf_parser.h>
 #include <urdf_parser_plugin/parser.h>
 
+#include <string>
+
 namespace urdf
 {
 class URDFXMLParser : public urdf::URDFParser
 {
 public:
-
   URDFXMLParser() = default;
 
   virtual ~URDFXMLParser() = default;
 
-  urdf::ModelInterfaceSharedPtr parse(const std::string& xml_string) override;
+  urdf::ModelInterfaceSharedPtr parse(const std::string & xml_string) override;
 
   size_t might_handle(const std::string & data) override;
 };
 
-urdf::ModelInterfaceSharedPtr URDFXMLParser::parse(const std::string &xml_string)
+urdf::ModelInterfaceSharedPtr URDFXMLParser::parse(const std::string & xml_string)
 {
   return urdf::parseURDF(xml_string);
 }
 
-size_t URDFXMLParser::might_handle(const std::string &data)
+size_t URDFXMLParser::might_handle(const std::string & data)
 {
   // probably a urdf file if <robot is near the start of the document
   return data.find("<robot");

--- a/urdf/src/urdf_plugin.cpp
+++ b/urdf/src/urdf_plugin.cpp
@@ -32,9 +32,11 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
+#include <tinyxml2.h>
 #include <urdf_parser/urdf_parser.h>
 #include <urdf_parser_plugin/parser.h>
 
+#include <limits>
 #include <string>
 
 namespace urdf
@@ -58,7 +60,21 @@ urdf::ModelInterfaceSharedPtr URDFXMLParser::parse(const std::string & xml_strin
 
 size_t URDFXMLParser::might_handle(const std::string & data)
 {
-  // probably a urdf file if <robot is near the start of the document
+  tinyxml2::XMLDocument doc;
+  const tinyxml2::XMLError error = doc.Parse(data.c_str());
+  if (error == tinyxml2::XML_SUCCESS) {
+    // Since it's an XML document it must have `<robot>` as the first tag
+    const tinyxml2::XMLElement * root = doc.RootElement();
+    if (std::string("robot") != root->Name()) {
+      std::cout << "'" << root->Name() << "'\n";
+      return std::numeric_limits<size_t>::max();
+    }
+  }
+
+  // Possiblities:
+  //  1) It is not an XML based robot description
+  //  2) It is an XML based robot description, but there's an XML syntax error
+  //  3) It is a URDF XML with correct XML syntax
   return data.find("<robot");
 }
 }  // namespace urdf

--- a/urdf/src/urdf_plugin.cpp
+++ b/urdf/src/urdf_plugin.cpp
@@ -36,7 +36,6 @@
 #include <urdf_parser/urdf_parser.h>
 #include <urdf_parser_plugin/parser.h>
 
-#include <limits>
 #include <string>
 
 namespace urdf
@@ -66,7 +65,7 @@ size_t URDFXMLParser::might_handle(const std::string & data)
     // Since it's an XML document it must have `<robot>` as the first tag
     const tinyxml2::XMLElement * root = doc.RootElement();
     if (std::string("robot") != root->Name()) {
-      return std::numeric_limits<size_t>::max();
+      return data.size();
     }
   }
 

--- a/urdf/src/urdf_plugin.cpp
+++ b/urdf/src/urdf_plugin.cpp
@@ -41,12 +41,12 @@
 
 namespace urdf
 {
-class URDFXMLParser : public urdf::URDFParser
+class URDFXMLParser final : public urdf::URDFParser
 {
 public:
   URDFXMLParser() = default;
 
-  virtual ~URDFXMLParser() = default;
+  ~URDFXMLParser() = default;
 
   urdf::ModelInterfaceSharedPtr parse(const std::string & xml_string) override;
 

--- a/urdf/test/benchmark_plugin_overhead.cpp
+++ b/urdf/test/benchmark_plugin_overhead.cpp
@@ -1,0 +1,81 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2020, Willow Garage, Inc.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+#include <benchmark/benchmark.h>
+#include <urdf_parser/urdf_parser.h>
+
+#include <string>
+
+#include "urdf/model.h"
+
+const char test_xml[] =
+  "<?xml verison=\"1.0\"?>"
+  "<robot name=\"benchy_bot\">"
+  "  <link name=\"link1\">"
+  "    <inertial>"
+  "      <mass value=\"1\"/>"
+  "      <inertia ixx=\"1\" iyy=\"1\" izz=\"1\" ixy=\"0\" ixz=\"0\" iyz=\"0\"/>"
+  "    </inertial>"
+  "    <visual>"
+  "      <geometry>"
+  "        <box size=\"1 1 1\"/>"
+  "      </geometry>"
+  "    </visual>"
+  "    <collision>"
+  "      <geometry>"
+  "        <box size=\"1 1 1\"/>"
+  "      </geometry>"
+  "    </collision>"
+  "  </link>"
+  "</robot>";
+
+static void BM_no_plugin(benchmark::State & state)
+{
+  for (auto _ : state) {
+    urdf::parseURDF(test_xml);
+  }
+}
+
+static void BM_with_plugin(benchmark::State & state)
+{
+  for (auto _ : state) {
+    urdf::Model m;
+    m.initString(test_xml);
+  }
+}
+
+BENCHMARK(BM_no_plugin);
+BENCHMARK(BM_with_plugin);
+
+BENCHMARK_MAIN();

--- a/urdf/test/benchmark_plugin_overhead.cpp
+++ b/urdf/test/benchmark_plugin_overhead.cpp
@@ -63,7 +63,10 @@ const char test_xml[] =
 static void BM_no_plugin(benchmark::State & state)
 {
   for (auto _ : state) {
-    urdf::parseURDF(test_xml);
+    if (nullptr == urdf::parseURDF(test_xml)) {
+      state.SkipWithError("Failed to read xml");
+      break;
+    }
   }
 }
 
@@ -71,7 +74,10 @@ static void BM_with_plugin(benchmark::State & state)
 {
   for (auto _ : state) {
     urdf::Model m;
-    m.initString(test_xml);
+    if (!m.initString(test_xml)) {
+      state.SkipWithError("Failed to read xml");
+      break;
+    }
   }
 }
 

--- a/urdf/urdf_parser_description.xml
+++ b/urdf/urdf_parser_description.xml
@@ -1,0 +1,7 @@
+<library path="urdf_xml_parser">
+  <class name="urdf_xml_parser/URDFXMLParser" type="urdf::URDFXMLParser" base_class_type="urdf::URDFParser">
+    <description>
+      Parse models as URDF from URDF XML.
+    </description>
+  </class>
+</library>

--- a/urdf_parser_plugin/CMakeLists.txt
+++ b/urdf_parser_plugin/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12.2)
+cmake_minimum_required(VERSION 3.5)
 project(urdf_parser_plugin)
 
 find_package(ament_cmake_ros REQUIRED)

--- a/urdf_parser_plugin/CMakeLists.txt
+++ b/urdf_parser_plugin/CMakeLists.txt
@@ -9,6 +9,9 @@ add_library(urdf_parser_plugin INTERFACE)
 target_include_directories(urdf_parser_plugin INTERFACE
   $<INSTALL_INTERFACE:include>
 )
+ament_target_dependencies(urdf_parser_plugin INTERFACE
+  "urdfdom_headers"
+)
 install(TARGETS urdf_parser_plugin EXPORT urdf_parser_plugin-export)
 ament_export_targets(urdf_parser_plugin-export)
 

--- a/urdf_parser_plugin/CMakeLists.txt
+++ b/urdf_parser_plugin/CMakeLists.txt
@@ -1,13 +1,20 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.12.2)
 project(urdf_parser_plugin)
 
-find_package(catkin REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 find_package(urdfdom_headers REQUIRED)
 
-catkin_package(
-  INCLUDE_DIRS include
-  DEPENDS urdfdom_headers 
+# Create and export a header-only target
+add_library(urdf_parser_plugin INTERFACE)
+target_include_directories(urdf_parser_plugin INTERFACE
+  $<INSTALL_INTERFACE:include>
+)
+install(TARGETS urdf_parser_plugin EXPORT urdf_parser_plugin-export)
+ament_export_targets(urdf_parser_plugin-export)
+
+install(
+  DIRECTORY include/
+  DESTINATION include
 )
 
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+ament_package()

--- a/urdf_parser_plugin/include/urdf_parser_plugin/parser.h
+++ b/urdf_parser_plugin/include/urdf_parser_plugin/parser.h
@@ -61,7 +61,8 @@ public:
 
   /// \brief Indicate if data is meant to be parsed by this parser
   /// \return confidence that the data is meant for this parser, where smaller
-  ///         values mean more confident, and 0 is absolute certainty.
+  ///         values mean more confidence, 0 is absolute certainty, and
+  ///         std::numeric_limits<size_t>::max() is no confidence.
   virtual size_t might_handle(const std::string & data) = 0;
 };
   

--- a/urdf_parser_plugin/include/urdf_parser_plugin/parser.h
+++ b/urdf_parser_plugin/include/urdf_parser_plugin/parser.h
@@ -39,6 +39,8 @@
 
 #include <urdf_world/types.h>
 
+#include <string>
+
 namespace urdf
 {
 

--- a/urdf_parser_plugin/include/urdf_parser_plugin/parser.h
+++ b/urdf_parser_plugin/include/urdf_parser_plugin/parser.h
@@ -37,13 +37,13 @@
 #ifndef URDF_PARSER_PLUGIN_H
 #define URDF_PARSER_PLUGIN_H
 
-#include <urdf/urdfdom_compatibility.h>
+#include <urdf_world/types.h>
 
 namespace urdf
 {
 
 /** \brief Base class for URDF parsers */
-class URDFParser 
+class URDFParser
 {
 public:
   URDFParser()
@@ -54,7 +54,13 @@ public:
   }
 
   /// \brief Load Model from string
-  virtual urdf::ModelInterfaceSharedPtr parse(const std::string &xml_string) = 0;
+  /// \return nullptr and write to stderr if the given string is invalid
+  virtual urdf::ModelInterfaceSharedPtr parse(const std::string & data) = 0;
+
+  /// \brief Indicate if data is meant to be parsed by this parser
+  /// \return confidence that the data is meant for this parser, where smaller
+  ///         values mean more confident, and 0 is absolute certainty.
+  virtual size_t might_handle(const std::string & data) = 0;
 };
   
 }

--- a/urdf_parser_plugin/include/urdf_parser_plugin/parser.h
+++ b/urdf_parser_plugin/include/urdf_parser_plugin/parser.h
@@ -60,9 +60,14 @@ public:
   virtual urdf::ModelInterfaceSharedPtr parse(const std::string & data) = 0;
 
   /// \brief Indicate if data is meant to be parsed by this parser
-  /// \return confidence that the data is meant for this parser, where smaller
-  ///         values mean more confidence, 0 is absolute certainty, and
-  ///         std::numeric_limits<size_t>::max() is no confidence.
+  /// \return The position in the string that the plugin became confident the
+  ///         data is intended to be parsed by it.
+  ///         For example, the plugin parsing COLLADA files might return the
+  ///         position in the string that the '<COLLADA>' xml tag was found.
+  ///         Smaller values are interpretted as more confidence, and the
+  ///         plugin with the smallest value is used to parse the data.
+  ///         If a plugin believes data is not meant for it, then it should
+  ///         return a value greater than or equal to data.size().
   virtual size_t might_handle(const std::string & data) = 0;
 };
   

--- a/urdf_parser_plugin/package.xml
+++ b/urdf_parser_plugin/package.xml
@@ -18,7 +18,7 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <build_depend>liburdfdom-headers-dev</build_depend>
-  <exec_depend>liburdfdom-headers-dev</exec_depend>
+  <build_export_depend>liburdfdom-headers-dev</build_export_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/urdf_parser_plugin/package.xml
+++ b/urdf_parser_plugin/package.xml
@@ -17,7 +17,6 @@
   <url type="bugtracker">https://github.com/ros2/urdf/issues</url>
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
-  <buildtool_export_depend>ament_cmake_ros</buildtool_export_depend>
   <build_depend>liburdfdom-headers-dev</build_depend>
   <exec_depend>liburdfdom-headers-dev</exec_depend>
 

--- a/urdf_parser_plugin/package.xml
+++ b/urdf_parser_plugin/package.xml
@@ -17,8 +17,9 @@
   <url type="bugtracker">https://github.com/ros2/urdf/issues</url>
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
-  <build_depend>liburdfdom-headers-dev</build_depend>
-  <build_export_depend>liburdfdom-headers-dev</build_export_depend>
+  <!-- Use ROS 2 urdfdom_headers package because upstream is out of date -->
+  <build_depend>urdfdom_headers</build_depend>
+  <build_export_depend>urdfdom_headers</build_export_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/urdf_parser_plugin/package.xml
+++ b/urdf_parser_plugin/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>urdf_parser_plugin</name>
   <version>2.2.0</version>
   <description>
@@ -16,8 +16,13 @@
   <url type="repository">https://github.com/ros2/urdf</url>
   <url type="bugtracker">https://github.com/ros2/urdf/issues</url>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_export_depend>ament_cmake_ros</buildtool_export_depend>
   <build_depend>liburdfdom-headers-dev</build_depend>
-  <run_depend>liburdfdom-headers-dev</run_depend>
+  <exec_depend>liburdfdom-headers-dev</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 
 </package>


### PR DESCRIPTION
This makes the urdf package load parser plugins, so it can use collada or sdformat parser plugins in the future.
It also makes the urdf xml parser a plugin instead of a special case.

A new api `might_handle()` returns a score for how likely it is a given string is meant for the plugin.
Right now the implementation is very simple, and a bit fragile.
The URDF plugin uses the position of the text `<robot` as the score.

This breaks ABI with urdf::Model because it now stores the class
loader instance, so everything downstream of this change must be rebuilt.

@scpeters @iantheengineer FYI

Requires https://github.com/ros/pluginlib/pull/199