### PR TITLE
Remove TinyXML dependency from urdf.

### DIFF
--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -6,12 +6,10 @@ find_package(pluginlib REQUIRED)
 find_package(urdf_parser_plugin REQUIRED)
 find_package(urdfdom REQUIRED)
 find_package(urdfdom_headers REQUIRED)
-find_package(tinyxml_vendor REQUIRED)
-find_package(TinyXML REQUIRED)
 
 # Find version components
 if(NOT urdfdom_headers_VERSION)
-set(urdfdom_headers_VERSION "0.0.0")
+  set(urdfdom_headers_VERSION "0.0.0")
 endif()
 string(REGEX REPLACE "^([0-9]+).*" "\\1" URDFDOM_HEADERS_MAJOR_VERSION "${urdfdom_headers_VERSION}")
 string(REGEX REPLACE "^[0-9]+\\.([0-9]+).*" "\\1" URDFDOM_HEADERS_MINOR_VERSION "${urdfdom_headers_VERSION}")
@@ -39,7 +37,10 @@ ament_target_dependencies(${PROJECT_NAME}
   urdfdom
   urdfdom_headers
   pluginlib
-  TinyXML)
+)
+target_link_libraries(${PROJECT_NAME}
+  urdfdom::urdfdom_model
+)
 
 if(WIN32)
   target_compile_definitions(${PROJECT_NAME} PRIVATE "URDF_BUILDING_DLL")
@@ -109,8 +110,6 @@ ament_export_libraries(${PROJECT_NAME})
 ament_export_targets(${PROJECT_NAME})
 ament_export_include_directories(include)
 ament_export_dependencies(pluginlib)
-ament_export_dependencies(tinyxml_vendor)
-ament_export_dependencies(TinyXML)
 ament_export_dependencies(urdf_parser_plugin)
 ament_export_dependencies(urdfdom)
 ament_export_dependencies(urdfdom_headers)

--- a/urdf/include/urdf/model.h
+++ b/urdf/include/urdf/model.h
@@ -40,7 +40,6 @@
 #include <memory>
 #include <string>
 
-#include "tinyxml.h"  // NOLINT
 #include "urdf_model/model.h"
 
 #include "urdf/urdfdom_compatibility.h"
@@ -66,13 +65,6 @@ public:
 
   URDF_EXPORT
   ~Model();
-
-  /// \brief Load Model from TiXMLElement
-  [[deprecated("use initString instead")]]
-  URDF_EXPORT bool initXml(TiXmlElement * xml);
-  /// \brief Load Model from TiXMLDocument
-  [[deprecated("use initString instead")]]
-  URDF_EXPORT bool initXml(TiXmlDocument * xml);
 
   /// \brief Load Model given a filename
   URDF_EXPORT bool initFile(const std::string & filename);

--- a/urdf/package.xml
+++ b/urdf/package.xml
@@ -15,29 +15,23 @@
 
   <license>BSD</license>
 
-  <!--url type="website">http://ros.org/wiki/urdf</url-->
   <url type="repository">https://github.com/ros2/urdf</url>
   <url type="bugtracker">https://github.com/ros2/urdf/issues</url>
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <build_depend>pluginlib</build_depend>
-  <build_depend>tinyxml</build_depend>
-  <build_depend>tinyxml_vendor</build_depend>
   <build_depend>urdfdom</build_depend>
   <build_depend>urdf_parser_plugin</build_depend>
   <!-- use ROS 2 package urdfdom_headers until upstream provides 1.0.0.-->
   <build_depend>urdfdom_headers</build_depend>
 
   <exec_depend>pluginlib</exec_depend>
-  <exec_depend>tinyxml</exec_depend>
-  <exec_depend>tinyxml_vendor</exec_depend>
   <exec_depend>urdfdom</exec_depend>
   <!-- use ROS 2 package urdfdom_headers until upstream provides 1.0.0.-->
   <exec_depend>urdfdom_headers</exec_depend>
 
   <build_export_depend>pluginlib</build_export_depend>
-  <build_export_depend>tinyxml</build_export_depend>
   <build_export_depend>urdf_parser_plugin</build_export_depend>
   <build_export_depend>urdfdom</build_export_depend>
   <!-- use ROS 2 package urdfdom_headers until upstream provides 1.0.0.-->

--- a/urdf/src/model.cpp
+++ b/urdf/src/model.cpp
@@ -96,58 +96,6 @@ bool Model::initFile(const std::string & filename)
   }
 }
 
-/*
-bool Model::initParam(const std::string & param)
-{
-  return initParamWithNodeHandle(param, ros::NodeHandle());
-}
-
-bool Model::initParamWithNodeHandle(const std::string & param, const ros::NodeHandle & nh)
-{
-  std::string xml_string;
-
-  // gets the location of the robot description on the parameter server
-  std::string full_param;
-  if (!nh.searchParam(param, full_param)){
-    ROS_ERROR("Could not find parameter %s on parameter server", param.c_str());
-    return false;
-  }
-
-  // read the robot description from the parameter server
-  if (!nh.getParam(full_param, xml_string)){
-    ROS_ERROR("Could not read parameter %s on parameter server", full_param.c_str());
-    return false;
-  }
-  return Model::initString(xml_string);
-}
-*/
-
-bool Model::initXml(TiXmlDocument * xml_doc)
-{
-  if (!xml_doc) {
-    fprintf(stderr, "Could not parse the xml document.\n");
-    return false;
-  }
-
-  std::stringstream ss;
-  ss << *xml_doc;
-
-  return Model::initString(ss.str());
-}
-
-bool Model::initXml(TiXmlElement * robot_xml)
-{
-  if (!robot_xml) {
-    fprintf(stderr, "Could not parse the xml element.\n");
-    return false;
-  }
-
-  std::stringstream ss;
-  ss << (*robot_xml);
-
-  return Model::initString(ss.str());
-}
-
 pluginlib::UniquePtr<urdf::URDFParser>
 ModelImplementation::load_plugin(const std::string & plugin_name)
 {


### PR DESCRIPTION
It was deprecated in Foxy, so we can remove it for Galactic.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

@sloretz This will conflict with #13, but it should be relatively easy to resolve.