### PR TITLE
Work around Windows min/max bug.

### DIFF
--- a/urdf/src/model.cpp
+++ b/urdf/src/model.cpp
@@ -46,13 +46,11 @@
 #include <utility>
 #include <vector>
 
-// Windows has preprocessor defines for "min" and "max", which conflict with
+// Windows has preprocessor defines for "max", which conflicts with
 // several things (one of them being std::numeric_limits<T>::max()).  Since
-// we know we aren't going to use those macros, we save them off at the top of
-// the file (with "pragma push_macro"), use whatever variants of "min" and "max"
-// we need, and the restore the macros at the end of the file (with "pragma pop_macro")
+// we know we aren't going to use that macros, and this is a cpp (not header
+// file), we just undefine it on Windows.
 #ifdef _WIN32
-#pragma push_macro("max")
 #undef max
 #endif
 
@@ -169,7 +167,3 @@ bool Model::initString(const std::string & data)
   return true;
 }
 }  // namespace urdf
-
-#ifdef _WIN32
-#pragma pop_macro("max")
-#endif

--- a/urdf/src/model.cpp
+++ b/urdf/src/model.cpp
@@ -46,6 +46,13 @@
 #include <utility>
 #include <vector>
 
+// Windows has preprocessor defines for "min" and "max", which can cause
+// problems when things like std::numeric_limits<int>::max are used.  This
+// macro is used to defeat the macro matching logic and hence workaround the
+// issue.  The idea comes from:
+// https://stackoverflow.com/questions/11544073/how-do-i-deal-with-the-max-macro-in-windows-h-colliding-with-max-in-std/11550864#11550864
+#define PREVENT_WINDOWS_MIN_MAX
+
 
 namespace urdf
 {
@@ -112,7 +119,7 @@ bool Model::initString(const std::string & data)
 {
   urdf::ModelInterfaceSharedPtr model;
 
-  size_t best_score = std::numeric_limits<size_t>::max();
+  size_t best_score = std::numeric_limits<size_t>::max PREVENT_WINDOWS_MIN_MAX();
   auto best_plugin = pluginlib::UniquePtr<urdf::URDFParser>{nullptr};
   std::string best_plugin_name;
 

--- a/urdf/src/model.cpp
+++ b/urdf/src/model.cpp
@@ -46,13 +46,15 @@
 #include <utility>
 #include <vector>
 
-// Windows has preprocessor defines for "min" and "max", which can cause
-// problems when things like std::numeric_limits<int>::max are used.  This
-// macro is used to defeat the macro matching logic and hence workaround the
-// issue.  The idea comes from:
-// https://stackoverflow.com/questions/11544073/how-do-i-deal-with-the-max-macro-in-windows-h-colliding-with-max-in-std/11550864#11550864
-#define PREVENT_WINDOWS_MIN_MAX
-
+// Windows has preprocessor defines for "min" and "max", which conflict with
+// several things (one of them being std::numeric_limits<T>::max()).  Since
+// we know we aren't going to use those macros, we save them off at the top of
+// the file (with "pragma push_macro"), use whatever variants of "min" and "max"
+// we need, and the restore the macros at the end of the file (with "pragma pop_macro")
+#ifdef _WIN32
+#pragma push_macro("max")
+#undef max
+#endif
 
 namespace urdf
 {
@@ -119,7 +121,7 @@ bool Model::initString(const std::string & data)
 {
   urdf::ModelInterfaceSharedPtr model;
 
-  size_t best_score = std::numeric_limits<size_t>::max PREVENT_WINDOWS_MIN_MAX();
+  size_t best_score = std::numeric_limits<size_t>::max();
   auto best_plugin = pluginlib::UniquePtr<urdf::URDFParser>{nullptr};
   std::string best_plugin_name;
 
@@ -167,3 +169,7 @@ bool Model::initString(const std::string & data)
   return true;
 }
 }  // namespace urdf
+
+#ifdef _WIN32
+#pragma pop_macro("max")
+#endif


### PR DESCRIPTION
The comments in the code explain why we need this.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Some upcoming changes to [pluginlib](https://github.com/ros/pluginlib/pull/212) are going to cause us to `#include <windows.h>`, which is why this is now needed to build on Windows.

One other note: I believe that there is an alternative way to solve this, which is to use MSVC [push_macro/pop_macro](https://docs.microsoft.com/en-us/cpp/preprocessor/pop-macro?view=msvc-160).  That is, we'd do something like:

```
#ifdef _WIN32
#pragma push_macro("max")
#undef max
#endif

// Use std::numeric_limits<size_t>::max();

#ifdef _WIN32
#pragma pop_macro("max")
#endif
```

Both are kind of ugly, so I don't have a strong opinion one way or another.