### PR TITLE
Provide copy and move constructors for `model`

### DIFF
--- a/urdf/include/urdf/model.h
+++ b/urdf/include/urdf/model.h
@@ -66,6 +66,11 @@ public:
   URDF_EXPORT
   ~Model();
 
+  URDF_EXPORT Model(const Model & other);
+  URDF_EXPORT Model & operator=(const Model & other);
+  URDF_EXPORT Model(Model && other) noexcept;
+  URDF_EXPORT Model & operator=(Model && other)noexcept;
+
   /// \brief Load Model given a filename
   URDF_EXPORT bool initFile(const std::string & filename);
 

--- a/urdf/src/model.cpp
+++ b/urdf/src/model.cpp
@@ -79,6 +79,24 @@ Model::Model()
 {
 }
 
+Model::Model(const Model & other)
+: ModelInterface(other), impl_(new ModelImplementation) {}
+
+Model & Model::operator=(const Model & other)
+{
+  return *this = Model(other);
+}
+
+Model::Model(Model && other) noexcept
+: ModelInterface(other), impl_(std::exchange(other.impl_, nullptr)) {}
+
+Model & Model::operator=(Model && other) noexcept
+{
+  ModelInterface::operator=(std::move(other));
+  std::swap(impl_, other.impl_);
+  return *this;
+}
+
 Model::~Model()
 {
   clear();


### PR DESCRIPTION
In 4b73ae2998bec0db24aca07b0bf7fc37b8e4dae7 the copy and move
constructors were accidentally disabled.
This means that one must always wrap a `urdf::Model` into some form of
pointer in order to pass it around or have it as a member.

This commit restores the copy and move constructors, such that one is
able to pass the `urdf::Model` around as a normal variable.

See also:
https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rc-five