### PR TITLE
[urdf] package.xml: add missing exec_depend to urdf_parser_plugin

### DIFF
--- a/urdf/package.xml
+++ b/urdf/package.xml
@@ -30,6 +30,8 @@
   <exec_depend>pluginlib</exec_depend>
   <exec_depend>tinyxml2_vendor</exec_depend>
   <exec_depend>urdfdom</exec_depend>
+  <!-- while `urdf_parser_plugin` itself its a header only lib, the `pluginlib` requires the package to exists during runtime. -->
+  <exec_depend>urdf_parser_plugin</exec_depend>
   <!-- use ROS 2 package urdfdom_headers until upstream provides 1.0.0.-->
   <exec_depend>urdfdom_headers</exec_depend>
 

--- a/urdf/package.xml
+++ b/urdf/package.xml
@@ -30,7 +30,7 @@
   <exec_depend>pluginlib</exec_depend>
   <exec_depend>tinyxml2_vendor</exec_depend>
   <exec_depend>urdfdom</exec_depend>
-  <!-- while `urdf_parser_plugin` itself its a header only lib, the `pluginlib` requires the package to exists during runtime. -->
+  <!-- while `urdf_parser_plugin` is a header only lib, `pluginlib` requires the package to exist during runtime. -->
   <exec_depend>urdf_parser_plugin</exec_depend>
   <!-- use ROS 2 package urdfdom_headers until upstream provides 1.0.0.-->
   <exec_depend>urdfdom_headers</exec_depend>


### PR DESCRIPTION
Because its been a build dependency that was probably not a visible problem in a normal ROS workspace.
However when used in context of openembedded (where the build space and runtime space are separated) this results in `urdf_parser_plugin` not been part of the image.

- FIX: [urdf] package.xml: add missing exec_depend to urdf_parser_plugin

fixup for ros2/urdf#13