### PR TITLE
Switch to target_link_libraries

### DIFF
--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -38,14 +38,13 @@ target_include_directories(${PROJECT_NAME}
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
 )
-ament_target_dependencies(${PROJECT_NAME}
-  urdf_parser_plugin
-  urdfdom
-  urdfdom_headers
-  pluginlib
-)
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PUBLIC
   urdfdom::urdfdom_model
+)
+target_link_libraries(${PROJECT_NAME} PRIVATE
+  urdf_parser_plugin::urdf_parser_plugin
+  urdfdom_headers::urdfdom_headers
+  pluginlib::pluginlib
 )
 
 if(WIN32)
@@ -59,13 +58,11 @@ endif()
 add_library(urdf_xml_parser SHARED
   src/urdf_plugin.cpp
 )
-target_link_libraries(urdf_xml_parser
+target_link_libraries(urdf_xml_parser PRIVATE
   ${PROJECT_NAME}
-)
-ament_target_dependencies(urdf_xml_parser
-  "pluginlib"
-  "TinyXML2"
-  "urdf_parser_plugin"
+  pluginlib::pluginlib
+  tinyxml2::tinyxml2
+  urdf_parser_plugin::urdf_parser_plugin
 )
 
 install(TARGETS urdf_xml_parser

--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -21,9 +21,10 @@ set(generated_compat_header "${generated_install_path}/${PROJECT_NAME}/urdfdom_c
 include_directories(${generated_install_path})
 configure_file(urdfdom_compatibility.h.in "${generated_compat_header}" @ONLY)
 
-# Default to C++14
+# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)

--- a/urdf_parser_plugin/CMakeLists.txt
+++ b/urdf_parser_plugin/CMakeLists.txt
@@ -9,8 +9,8 @@ add_library(urdf_parser_plugin INTERFACE)
 target_include_directories(urdf_parser_plugin INTERFACE
   $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
 )
-ament_target_dependencies(urdf_parser_plugin INTERFACE
-  "urdfdom_headers"
+target_link_libraries(urdf_parser_plugin INTERFACE
+  urdfdom_headers::urdfdom_headers
 )
 
 if(BUILD_TESTING)


### PR DESCRIPTION
That way, we can hide some of the internally used libraries from downstream consumers.

While we are in here, also switch to C++17.