### PR TITLE
Backport - Provide copy and move constructors for `model` (#33)

### DIFF
--- a/urdf/include/urdf/model.h
+++ b/urdf/include/urdf/model.h
@@ -66,6 +66,11 @@ public:
   URDF_EXPORT
   ~Model();
 
+  URDF_EXPORT Model(const Model & other);
+  URDF_EXPORT Model & operator=(const Model & other);
+  URDF_EXPORT Model(Model && other) noexcept;
+  URDF_EXPORT Model & operator=(Model && other)noexcept;
+
   /// \brief Load Model given a filename
   URDF_EXPORT bool initFile(const std::string & filename);
 

--- a/urdf/src/model.cpp
+++ b/urdf/src/model.cpp
@@ -79,6 +79,24 @@ Model::Model()
 {
 }
 
+Model::Model(const Model & other)
+: ModelInterface(other), impl_(new ModelImplementation) {}
+
+Model & Model::operator=(const Model & other)
+{
+  return *this = Model(other);
+}
+
+Model::Model(Model && other) noexcept
+: ModelInterface(other), impl_(std::exchange(other.impl_, nullptr)) {}
+
+Model & Model::operator=(Model && other) noexcept
+{
+  ModelInterface::operator=(std::move(other));
+  std::swap(impl_, other.impl_);
+  return *this;
+}
+
 Model::~Model()
 {
   clear();


### PR DESCRIPTION
Backport of #33, so copy and move are available in humble too.

These changes should be API/ABI compatible.

These constructors are available in ros 1 noetic and ros 2 iron onwards, just missing in humble