### PR TITLE
Removed urdf_world/types.h deprecation

### DIFF
--- a/urdf/urdfdom_compatibility.h.in
+++ b/urdf/urdfdom_compatibility.h.in
@@ -90,7 +90,6 @@ URDF_TYPEDEF_CLASS_POINTER(Model);
 #include <memory>
 
 #include "urdf_model/types.h"
-#include "urdf_world/types.h"
 
 namespace urdf
 {

--- a/urdf_parser_plugin/include/urdf_parser_plugin/parser.hpp
+++ b/urdf_parser_plugin/include/urdf_parser_plugin/parser.hpp
@@ -33,7 +33,7 @@
 
 #include <string>
 
-#include "urdf_world/types.h"
+#include "urdf_model/types.h"
 
 namespace urdf
 {


### PR DESCRIPTION
## Description

Related with this PR https://github.com/ros/urdfdom_headers/pull/99

There is a build warning https://ci.ros2.org/job/ci_linux/28574/clang-tidy/