### PR TITLE
Use pragma message for obsolete parser header on MSVC

### DIFF
--- a/urdf_parser_plugin/include/urdf_parser_plugin/parser.h
+++ b/urdf_parser_plugin/include/urdf_parser_plugin/parser.h
@@ -31,9 +31,13 @@
 #ifndef URDF_PARSER_PLUGIN__PARSER_H_
 #define URDF_PARSER_PLUGIN__PARSER_H_
 
+#ifdef _MSC_VER
+#pragma message("This header is obsolete, please include urdf_parser_plugin/parser.hpp instead")
+#else
 #warning \
   This header is obsolete, please include \
   urdf_parser_plugin/parser.hpp instead
+#endif
 
 #include <urdf_parser_plugin/parser.hpp>
 


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

This upstreams `patch/ros-rolling-urdf-parser-plugin.win.patch`, authored in RoboStack by wep21 `<daisuke.nishimatsu1021@gmail.com>`.

MSVC does not support the GCC-style `#warning` directive. This uses `#pragma message` for MSVC while preserving the existing warning on compilers that support it.