### PR TITLE
Fix the mock plugin install for the plugin_overhead benchmark.

### DIFF
--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -85,14 +85,14 @@ if(BUILD_TESTING)
   pluginlib_enable_plugin_testing(
     CMAKE_TARGET_VAR mock_install_target
     AMENT_PREFIX_PATH_VAR mock_install_path
-    PLUGIN_CATEGORY "urdf_parser"
+    PLUGIN_CATEGORY "urdf_parser_plugin"
     PLUGIN_DESCRIPTIONS "urdf_parser_description.xml"
     PLUGIN_LIBRARIES urdf_xml_parser
   )
 
   ament_add_google_benchmark(plugin_overhead
     test/benchmark_plugin_overhead.cpp
-    APPEND_ENV AMENT_PREFIX_PATH="${mock_install_path}"
+    APPEND_ENV AMENT_PREFIX_PATH=${mock_install_path}
   )
   target_link_libraries(plugin_overhead
     urdf

--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -92,7 +92,7 @@ if(BUILD_TESTING)
 
   ament_add_google_benchmark(plugin_overhead
     test/benchmark_plugin_overhead.cpp
-    APPEND_ENV AMENT_PREFIX_PATH=${mock_install_path}
+    APPEND_ENV "AMENT_PREFIX_PATH=${mock_install_path}"
   )
   target_link_libraries(plugin_overhead
     urdf


### PR DESCRIPTION
## Description

There are two fixes in here:

1.  Do not wrap the APPEND_ENV value in double quotes.  CMake passes the double quotes through as literal characters in the environment variable value, so the mock install path from pluginlib_enable_plugin_testing() was silently skipped when searching for plugins at test time.

2.  Register the mock plugin description under the "urdf_parser_plugin" plugin category, which is the category that urdf::Model actually loads parser plugins from (and that the real package exports).

While the result is more correct, the scenario it fixes is incredibly niche: when you are building this package *without colcon* and with the performance tests enabled, this makes the performance tests work. In all other scenarios this is a no-op.

### Is this user-facing behavior change?

No.

### Did you use Generative AI?

Yes, Claude Fable 5.

### Additional Information

N/A